### PR TITLE
Increased MQTT buffer to work with Aidon 6525 meters

### DIFF
--- a/src/AmsToMqttBridge.ino
+++ b/src/AmsToMqttBridge.ino
@@ -45,7 +45,7 @@ AmsConfiguration config;
 AmsWebServer ws;
 
 WiFiClient *client;
-MQTTClient mqtt(384);
+MQTTClient mqtt(512);
 
 Stream* debugger = NULL;
 


### PR DESCRIPTION
This fixes: https://github.com/gskjold/AmsToMqttBridge/issues/52