### PR TITLE
Add devkit boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -61,3 +61,21 @@ lib_deps = ${common.lib_deps}
 extra_scripts =
     pre:scripts/addversion.py
     scripts/makeweb.py
+
+[env:az-delivery-devkit-v4]
+platform = espressif32@1.11.2
+board = az-delivery-devkit-v4
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+extra_scripts =
+    pre:scripts/addversion.py
+    scripts/makeweb.py
+
+[env:esp32doit-devkit-v1]
+platform = espressif32@1.11.2
+board = esp32doit-devkit-v1
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+extra_scripts =
+    pre:scripts/addversion.py
+    scripts/makeweb.py

--- a/src/AmsToMqttBridge.h
+++ b/src/AmsToMqttBridge.h
@@ -56,6 +56,14 @@ SoftwareSerial *hanSerial = new SoftwareSerial(D1);
 
 HardwareSerial *hanSerial = &Serial2;
 
+// Build settings for AZ-Delivery ESP-32 DevKitC V4 and DOIT DevKit V1
+#elif defined(ARDUINO_ESP32_DEV)
+#define LED_PIN 2                        // external 2 for V4 , 2 for doit v1   
+#define LED_ACTIVE_HIGH 1
+#define AP_BUTTON_PIN 0
+
+HardwareSerial *hanSerial = &Serial2;    // use gpio 16 for rx2 
+
 // Default build for ESP32
 #elif defined(ESP32)
 #define LED_PIN INVALID_BUTTON_PIN


### PR DESCRIPTION
This proposed change adds support for two new esp32 boards:
-DOIT (also branded GEEKREIT)  Devkit V1 
  (https://docs.platformio.org/en/latest/boards/espressif32/esp32doit-devkit-v1.html)
-AZ-Delivery DevkitC V4   
  (https://docs.platformio.org/en/latest/boards/espressif32/az-delivery-devkit-v4.html)
