### PR TITLE
Libdeps updated to avoid conflict with time.h

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 extra_configs = platformio-user.ini
 
 [common]
-lib_deps = file://lib/Timezone, 256dpi/MQTT@2.5.0, OneWireNg@0.10.0, DallasTemperature@3.9.1, EspSoftwareSerial@6.14.1, https://github.com/gskjold/RemoteDebug.git, Time@1.6.0
+lib_deps = https://github.com/JChristensen/Timezone.git@1.2.4, 256dpi/MQTT@2.5.0, OneWireNg@0.10.0, DallasTemperature@3.9.1, EspSoftwareSerial@6.14.1, https://github.com/gskjold/RemoteDebug.git, https://github.com/PaulStoffregen/Time.git@1.6.1
 lib_ignore = OneWire
 
 [env:esp8266]

--- a/src/hexutils.cpp
+++ b/src/hexutils.cpp
@@ -1,4 +1,4 @@
-#include "hexutils.h";
+#include "hexutils.h"
 
 String toHex(uint8_t* in) {
 	return toHex(in, sizeof(in)*2);


### PR DESCRIPTION
Was unable to build, a lot of errors on time() functions.
Resolved with comment in https://github.com/PaulStoffregen/Time/releases/tag/v1.6.1
Also fixed warning on hexutils include.