### PR TITLE
Change time.h to timelib.h for 32bit to compile

### DIFF
--- a/src/entsoe/EntsoeApi.h
+++ b/src/entsoe/EntsoeApi.h
@@ -1,7 +1,7 @@
 #ifndef _ENTSOEAPI_H
 #define _ENTSOEAPI_H
 
-#include "time.h"
+#include "TimeLib.h"
 #include "Timezone.h"
 #include "RemoteDebug.h"
 #include "EntsoeA44Parser.h"


### PR DESCRIPTION
I still had problems compiling in vscode and platformio on windows, this solved all errors to missing time()