### PR TITLE
publish ESP free mem in mqtt publishSystem

### DIFF
--- a/src/mqtt/RawMqttHandler.cpp
+++ b/src/mqtt/RawMqttHandler.cpp
@@ -211,6 +211,7 @@ bool RawMqttHandler::publishSystem(HwTools* hw) {
 	if(vcc > 0) {
 		mqtt->publish(topic + "/vcc", String(vcc, 2));
 	}
+	mqtt->publish(topic + "/mem", String(ESP.getFreeHeap()));
 	mqtt->publish(topic + "/rssi", String(hw->getWifiRssi()));
     if(hw->getTemperature() > -85) {
 		mqtt->publish(topic + "/temperature", String(hw->getTemperature(), 2));


### PR DESCRIPTION
Publish mem free (ESP.getFreeHeap()) in MQTT Raw see #174 comment from @ArnieO  https://github.com/gskjold/AmsToMqttBridge/issues/174#issuecomment-1045984491